### PR TITLE
Add `throws_expr!` and `try_expr!` for wrapping closures/async blocks

### DIFF
--- a/macros/src/args.rs
+++ b/macros/src/args.rs
@@ -51,13 +51,19 @@ impl Args {
     }
 }
 
+impl Default for Args {
+    fn default() -> Self {
+        Self {
+            error: Some(default_error()),
+            wrapper: Some(result()),
+        }
+    }
+}
+
 impl Parse for Args {
     fn parse(input: ParseStream) -> Result<Args> {
         if input.is_empty() {
-            return Ok(Args {
-                error: Some(default_error()),
-                wrapper: Some(result()),
-            });
+            return Ok(Args::default());
         }
 
         let error = match input.peek(Token![as]) {

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -19,3 +19,8 @@ pub fn try_fn(args: TokenStream, input: TokenStream) -> TokenStream {
     assert!(args.to_string() == "", "try_fn does not take arguments");
     Throws::new(None).fold(input)
 }
+
+#[proc_macro]
+pub fn throws_expr(input: TokenStream) -> TokenStream {
+    Throws::new(Some(Args::default())).fold(input)
+}

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -24,3 +24,8 @@ pub fn try_fn(args: TokenStream, input: TokenStream) -> TokenStream {
 pub fn throws_expr(input: TokenStream) -> TokenStream {
     Throws::new(Some(Args::default())).fold(input)
 }
+
+#[proc_macro]
+pub fn try_expr(input: TokenStream) -> TokenStream {
+    Throws::new(None).fold(input)
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -117,7 +117,10 @@
 //! # Annotating Expressions
 //!
 //! Attributes on expressions are still unstable, so there is a separate non-attribute macro
-//! [`throws_expr!`] available to wrap closures or async blocks.
+//! [`throws_expr!`] available to wrap closures or async blocks. This does not have any way to pass
+//! an error type, so only supports usage with a contextual "default error type". If you must
+//! override it for a single closure, you can do so by putting it in a block with a separate `use`
+//! or type alias.
 //!
 //! ## Example
 //!
@@ -137,6 +140,11 @@
 //!
 //!     println!("Okay!");
 //! });
+//!
+//! let string_throwing_closure = {
+//!     type Error = &'static str;
+//!     throws_expr!(|| throw!("This is not for you."))
+//! };
 //! ```
 
 #[doc(inline)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -113,6 +113,31 @@
 //! support `throws` syntax on functions that return `Poll` (so you can't use this syntax when
 //! implementing a `Future` by hand, for example). I hope to come up with a way to support `Poll`
 //! in the future.
+//!
+//! # Annotating Expressions
+//!
+//! Attributes on expressions are still unstable, so there is a separate non-attribute macro
+//! [`throws_expr!`] available to wrap closures or async blocks.
+//!
+//! ## Example
+//!
+//! ```
+//! use std::io::{self, Read, Error};
+//!
+//! use culpa::{throw, throws_expr};
+//!
+//! let closure = throws_expr!(|| {
+//!     let mut file = std::fs::File::open("The_House_of_the_Spirits.txt")?;
+//!     let mut text = String::new();
+//!     file.read_to_string(&mut text)?;
+//!
+//!     if !text.starts_with("Barrabas came to us by sea, the child Clara wrote") {
+//!         throw!(Error::from_raw_os_error(22));
+//!     }
+//!
+//!     println!("Okay!");
+//! });
+//! ```
 
 #[doc(inline)]
 /// Annotates a function that "throws" a Result.
@@ -125,6 +150,14 @@ pub use culpa_macros::throws;
 ///
 /// See the main crate docs for more details.
 pub use culpa_macros::try_fn;
+
+#[doc(inline)]
+/// Annotates an expression (closure or async block) that "throws" a Result.
+///
+/// Workaround for attributes on expressions being unstable.
+///
+/// See the main crate docs for more details.
+pub use culpa_macros::throws_expr;
 
 /// Throw an error.
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -116,18 +116,19 @@
 //!
 //! # Annotating Expressions
 //!
-//! Attributes on expressions are still unstable, so there is a separate non-attribute macro
-//! [`throws_expr!`] available to wrap closures or async blocks. This does not have any way to pass
-//! an error type, so only supports usage with a contextual "default error type". If you must
-//! override it for a single closure, you can do so by putting it in a block with a separate `use`
-//! or type alias.
+//! Attributes on expressions are still unstable, so there are separate non-attribute macro
+//! [`throws_expr!`] and [`try_expr!`] available to wrap closures or async blocks. `throws_expr!`
+//! does not have any way to pass an error type, so only supports usage with a contextual "default
+//! error type". If you must override it for a single closure, you can do so by putting it in a
+//! block with a separate `use` or type alias, or simply use `try_expr!` with a normal closure
+//! return type annotation.
 //!
 //! ## Example
 //!
 //! ```
 //! use std::io::{self, Read, Error};
 //!
-//! use culpa::{throw, throws_expr};
+//! use culpa::{throw, throws_expr, try_expr};
 //!
 //! let closure = throws_expr!(|| {
 //!     let mut file = std::fs::File::open("The_House_of_the_Spirits.txt")?;
@@ -145,6 +146,14 @@
 //!     type Error = &'static str;
 //!     throws_expr!(|| throw!("This is not for you."))
 //! };
+//!
+//! let string_throwing_closure = try_expr!(|| -> Result<_, &'static str> {
+//!     throw!("The air trembles. A breath of change passes…")
+//! });
+//!
+//! let maybe_random = try_expr!(|| -> Option<_> {
+//!     4
+//! });
 //! ```
 
 #[doc(inline)]
@@ -166,6 +175,14 @@ pub use culpa_macros::try_fn;
 ///
 /// See the main crate docs for more details.
 pub use culpa_macros::throws_expr;
+
+#[doc(inline)]
+/// Annotates an expression (closure or async block) that implicitly wraps a try block.
+///
+/// Workaround for attributes on expressions being unstable.
+///
+/// See the main crate docs for more details.
+pub use culpa_macros::try_expr;
 
 /// Throw an error.
 ///

--- a/tests/throws_expr_async_block.rs
+++ b/tests/throws_expr_async_block.rs
@@ -1,0 +1,87 @@
+use culpa::{throw, throws_expr};
+
+#[test]
+#[allow(clippy::unused_unit)]
+fn unit() {
+    type Error = ();
+    let ok = Result::<(), ()>::Ok(());
+    assert_eq!(ok, poll(throws_expr!(async {})));
+    assert_eq!(ok, poll(throws_expr!(async { () })));
+    assert_eq!(
+        ok,
+        poll(throws_expr!(async {
+            return;
+        }))
+    );
+    assert_eq!(
+        ok,
+        poll(throws_expr!(async {
+            return ();
+        }))
+    );
+}
+
+#[test]
+fn integer() {
+    type Error = ();
+    let ok = Result::<i32, ()>::Ok(1);
+    assert_eq!(ok, poll(throws_expr!(async { 1 })));
+    assert_eq!(
+        ok,
+        poll(throws_expr!(async {
+            return 1;
+        }))
+    );
+}
+
+#[test]
+fn throws_unit() {
+    type Error = ();
+    let err = Result::<(), ()>::Err(());
+    assert_eq!(err, poll(throws_expr!(async { throw!(()) })));
+}
+
+#[test]
+fn throws_integer() {
+    type Error = i32;
+    let err = Result::<(), i32>::Err(1);
+    assert_eq!(err, poll(throws_expr!(async { throw!(1) })));
+}
+
+#[test]
+fn has_inner_fn() {
+    type Error = ();
+    assert_eq!(
+        Result::<(), ()>::Ok(()),
+        poll(throws_expr!(async {
+            async fn foo() -> i32 {
+                5
+            }
+            assert_eq!(5, foo().await);
+        })),
+    );
+}
+
+#[test]
+fn has_inner_closure() {
+    type Error = ();
+    assert_eq!(
+        Result::<(), ()>::Ok(()),
+        poll(throws_expr!(async {
+            assert_eq!(5, async { 5 }.await);
+        })),
+    );
+}
+
+fn poll<F: std::future::Future>(f: F) -> F::Output {
+    struct NoopWake;
+    impl std::task::Wake for NoopWake {
+        fn wake(self: std::sync::Arc<Self>) {}
+    }
+    let std::task::Poll::Ready(output) = std::pin::pin!(f).poll(
+        &mut std::task::Context::from_waker(&std::sync::Arc::new(NoopWake).into()),
+    ) else {
+        panic!("future was not ready")
+    };
+    output
+}

--- a/tests/throws_expr_closure.rs
+++ b/tests/throws_expr_closure.rs
@@ -1,0 +1,76 @@
+#![allow(unused_braces)]
+#![allow(clippy::redundant_closure_call)]
+
+use culpa::{throw, throws_expr};
+
+#[test]
+#[rustfmt::skip]
+fn unit() {
+    type Error = ();
+    let ok = Result::<(), ()>::Ok(());
+    assert_eq!(ok, throws_expr!(|| {})());
+    assert_eq!(ok, throws_expr!(|| ())());
+    assert_eq!(ok, throws_expr!(|| -> () {})());
+    assert_eq!(ok, throws_expr!(|| { return; })());
+    assert_eq!(ok, throws_expr!(|| { return (); })());
+    assert_eq!(ok, throws_expr!(|| -> () { return; })());
+    assert_eq!(ok, throws_expr!(|| -> () { return (); })());
+}
+
+#[test]
+#[rustfmt::skip]
+fn integer() {
+    type Error = ();
+    let ok = Result::<i32, ()>::Ok(1);
+    assert_eq!(ok, throws_expr!(|| { 1 })());
+    assert_eq!(ok, throws_expr!(|| 1)());
+    assert_eq!(ok, throws_expr!(|| -> i32 { 1 })());
+    assert_eq!(ok, throws_expr!(|| { return 1; })());
+    assert_eq!(ok, throws_expr!(|| -> i32 { return 1; })());
+    assert_eq!(ok, throws_expr!(|| -> _ { 1 })());
+}
+
+#[test]
+#[rustfmt::skip]
+fn throws_unit() {
+    type Error = ();
+    let err = Result::<(), ()>::Err(());
+    assert_eq!(err, throws_expr!(|| { throw!(()) })());
+    assert_eq!(err, throws_expr!(|| throw!(()))());
+    assert_eq!(err, throws_expr!(|| -> () { throw!(()) })());
+}
+
+#[test]
+#[rustfmt::skip]
+fn throws_integer() {
+    type Error = i32;
+    let err = Result::<(), i32>::Err(1);
+    assert_eq!(err, throws_expr!(|| { throw!(1)} )());
+    assert_eq!(err, throws_expr!(|| throw!(1))());
+    assert_eq!(err, throws_expr!(|| -> () { throw!(1) })());
+}
+
+#[test]
+fn has_inner_fn() {
+    type Error = ();
+    assert_eq!(
+        Result::<(), ()>::Ok(()),
+        throws_expr!(|| {
+            fn foo() -> i32 {
+                5
+            }
+            assert_eq!(5, foo());
+        })(),
+    );
+}
+
+#[test]
+fn has_inner_closure() {
+    type Error = ();
+    assert_eq!(
+        Result::<(), ()>::Ok(()),
+        throws_expr!(|| {
+            assert_eq!(5, (|| 5)());
+        })(),
+    );
+}

--- a/tests/try_expr_async_block.rs
+++ b/tests/try_expr_async_block.rs
@@ -1,0 +1,119 @@
+use culpa::{throw, try_expr};
+
+#[test]
+#[allow(clippy::unused_unit)]
+fn unit() {
+    let ok = Result::<(), ()>::Ok(());
+    assert_eq!(ok, poll(try_expr!(async {})));
+    assert_eq!(ok, poll(try_expr!(async { () })));
+    assert_eq!(
+        ok,
+        poll(try_expr!(async {
+            return;
+        }))
+    );
+    assert_eq!(
+        ok,
+        poll(try_expr!(async {
+            return ();
+        }))
+    );
+}
+
+#[test]
+fn integer() {
+    let ok = Result::<i32, ()>::Ok(1);
+    assert_eq!(ok, poll(try_expr!(async { 1 })));
+    assert_eq!(
+        ok,
+        poll(try_expr!(async {
+            return 1;
+        }))
+    );
+}
+
+#[test]
+fn try_unit() {
+    let err = Result::<(), ()>::Err(());
+    assert_eq!(err, poll(try_expr!(async { throw!(()) })));
+}
+
+#[test]
+fn try_integer() {
+    let err = Result::<(), i32>::Err(1);
+    assert_eq!(err, poll(try_expr!(async { throw!(1) })));
+}
+
+#[test]
+fn has_inner_fn() {
+    assert_eq!(
+        Result::<(), ()>::Ok(()),
+        poll(try_expr!(async {
+            async fn foo() -> i32 {
+                5
+            }
+            assert_eq!(5, foo().await);
+        })),
+    );
+}
+
+#[test]
+fn has_inner_closure() {
+    assert_eq!(
+        Result::<(), ()>::Ok(()),
+        poll(try_expr!(async {
+            assert_eq!(5, async { 5 }.await);
+        })),
+    );
+}
+
+fn poll<F: std::future::Future>(f: F) -> F::Output {
+    struct NoopWake;
+    impl std::task::Wake for NoopWake {
+        fn wake(self: std::sync::Arc<Self>) {}
+    }
+    let std::task::Poll::Ready(output) = std::pin::pin!(f).poll(
+        &mut std::task::Context::from_waker(&std::sync::Arc::new(NoopWake).into()),
+    ) else {
+        panic!("future was not ready")
+    };
+    output
+}
+
+#[test]
+#[allow(clippy::unused_unit)]
+fn option_unit() {
+    let some = Option::<()>::Some(());
+    assert_eq!(some, poll(try_expr!(async {})));
+    assert_eq!(some, poll(try_expr!(async { () })));
+    assert_eq!(
+        some,
+        poll(try_expr!(async {
+            return;
+        }))
+    );
+    assert_eq!(
+        some,
+        poll(try_expr!(async {
+            return ();
+        }))
+    );
+}
+
+#[test]
+fn option_integer() {
+    let some = Option::<i32>::Some(1);
+    assert_eq!(some, poll(try_expr!(async { 1 })));
+    assert_eq!(
+        some,
+        poll(try_expr!(async {
+            return 1;
+        }))
+    );
+}
+
+#[test]
+fn option_throws() {
+    let none = Option::<()>::None;
+    assert_eq!(none, poll(try_expr!(async { throw!() })));
+}

--- a/tests/try_expr_closure.rs
+++ b/tests/try_expr_closure.rs
@@ -1,0 +1,104 @@
+#![allow(unused_braces)]
+#![allow(clippy::redundant_closure_call)]
+
+use culpa::{throw, try_expr};
+
+#[test]
+#[rustfmt::skip]
+fn unit() {
+    let ok = Result::<(), ()>::Ok(());
+    assert_eq!(ok, try_expr!(|| {})());
+    assert_eq!(ok, try_expr!(|| ())());
+    assert_eq!(ok, try_expr!(|| -> Result<(), ()> {})());
+    assert_eq!(ok, try_expr!(|| { return; })());
+    assert_eq!(ok, try_expr!(|| { return (); })());
+    assert_eq!(ok, try_expr!(|| -> Result<(), ()> { return; })());
+    assert_eq!(ok, try_expr!(|| -> Result<(), ()> { return (); })());
+}
+
+#[test]
+#[rustfmt::skip]
+fn integer() {
+    let ok = Result::<i32, ()>::Ok(1);
+    assert_eq!(ok, try_expr!(|| { 1 })());
+    assert_eq!(ok, try_expr!(|| 1)());
+    assert_eq!(ok, try_expr!(|| -> Result<i32, ()> { 1 })());
+    assert_eq!(ok, try_expr!(|| { return 1; })());
+    assert_eq!(ok, try_expr!(|| -> Result<i32, ()> { return 1; })());
+    assert_eq!(ok, try_expr!(|| -> _ { 1 })());
+}
+
+#[test]
+#[rustfmt::skip]
+fn throws_unit() {
+    let err = Result::<(), ()>::Err(());
+    assert_eq!(err, try_expr!(|| { throw!(()) })());
+    assert_eq!(err, try_expr!(|| throw!(()))());
+    assert_eq!(err, try_expr!(|| -> Result<(), ()> { throw!(()) })());
+}
+
+#[test]
+#[rustfmt::skip]
+fn throws_integer() {
+    let err = Result::<(), i32>::Err(1);
+    assert_eq!(err, try_expr!(|| { throw!(1)} )());
+    assert_eq!(err, try_expr!(|| throw!(1))());
+    assert_eq!(err, try_expr!(|| -> Result<(), i32> { throw!(1) })());
+}
+
+#[test]
+fn has_inner_fn() {
+    assert_eq!(
+        Result::<(), ()>::Ok(()),
+        try_expr!(|| {
+            fn foo() -> i32 {
+                5
+            }
+            assert_eq!(5, foo());
+        })(),
+    );
+}
+
+#[test]
+fn has_inner_closure() {
+    assert_eq!(
+        Result::<(), ()>::Ok(()),
+        try_expr!(|| {
+            assert_eq!(5, (|| 5)());
+        })(),
+    );
+}
+
+#[test]
+#[rustfmt::skip]
+fn option_unit() {
+    let some = Option::<()>::Some(());
+    assert_eq!(some, try_expr!(|| {})());
+    assert_eq!(some, try_expr!(|| ())());
+    assert_eq!(some, try_expr!(|| -> Option<()> {})());
+    assert_eq!(some, try_expr!(|| { return; })());
+    assert_eq!(some, try_expr!(|| { return (); })());
+    assert_eq!(some, try_expr!(|| -> Option<()> { return; })());
+    assert_eq!(some, try_expr!(|| -> Option<()> { return (); })());
+}
+
+#[test]
+#[rustfmt::skip]
+fn option_integer() {
+    let some = Option::<i32>::Some(1);
+    assert_eq!(some, try_expr!(|| { 1 })());
+    assert_eq!(some, try_expr!(|| 1)());
+    assert_eq!(some, try_expr!(|| -> Option<i32> { 1 })());
+    assert_eq!(some, try_expr!(|| { return 1; })());
+    assert_eq!(some, try_expr!(|| -> Option<i32> { return 1; })());
+    assert_eq!(some, try_expr!(|| -> _ { 1 })());
+}
+
+#[test]
+#[rustfmt::skip]
+fn option_throws() {
+    let none = Option::<()>::None;
+    assert_eq!(none, try_expr!(|| { throw!() })());
+    assert_eq!(none, try_expr!(|| throw!())());
+    assert_eq!(none, try_expr!(|| -> Option<()> { throw!() })());
+}


### PR DESCRIPTION
Also `#[throws]` should now work on closures/async blocks with the nightly feature active