### PR TITLE
Fix dead code warnings in tests

### DIFF
--- a/tests/throws.rs
+++ b/tests/throws.rs
@@ -144,6 +144,7 @@ pub fn unreachable() {
     todo!()
 }
 
+#[allow(dead_code)]
 trait Example {
     #[throws]
     fn foo() -> i32;

--- a/tests/try.rs
+++ b/tests/try.rs
@@ -141,6 +141,7 @@ pub fn unreachable() -> Result<(), i32> {
     todo!()
 }
 
+#[allow(dead_code)]
 trait Example {
     #[try_fn]
     fn foo() -> Result<i32, Error>;


### PR DESCRIPTION
https://github.com/rust-lang/rust/pull/118257 has improved the detection of unused traits